### PR TITLE
Update trigger docs

### DIFF
--- a/docs/widgets/point_field_map_widgets.rst
+++ b/docs/widgets/point_field_map_widgets.rst
@@ -145,11 +145,13 @@ Javascript Triggers
 If you need to develop your map UI on front-end side, you can use map widget jQuery triggers.
 
 
-* **google_point_map_widget:marker_create**: Triggered when user create marker on map. (callback params: place, lat, lng, locationInputElem, mapWrapID)
+* **google_point_map_widget:marker_create**: Triggered when user create marker on map. (callback params: lat, lng, locationInputElem, mapWrapID)
 
-* **google_point_map_widget:marker_change**: Triggered when user change marker position on map. (callback params: place, lat, lng, locationInputElem, mapWrapID)
+* **google_point_map_widget:marker_change**: Triggered when user change marker position on map. (callback params: lat, lng, locationInputElem, mapWrapID)
 
 * **google_point_map_widget:marker_delete**: Triggered when user delete marker on map. (callback params: lat, lng, locationInputElem, mapWrapID)
+
+* **google_point_map_widget:place_changed**: Triggered when the Google Places Autocomplete place changes (callback params: place, lat, lng, locationInputElem, mapWrapID)
 
 
 .. code-block:: javascript
@@ -173,4 +175,3 @@ If you need to develop your map UI on front-end side, you can use map widget jQu
         console.log(lat, lng);  // deleted marker coordinates
         console.log(mapWrapID); // map widget wrapper element ID
     })
-


### PR DESCRIPTION
The documentation for the `google_point_map_widget:place_changed` trigger is missing and the `marker_create` and `marker_change` callbacks don't actually pass `place` in.