### PR TITLE
remove references to pyproj

### DIFF
--- a/conf/requirements-dev.txt
+++ b/conf/requirements-dev.txt
@@ -2,5 +2,4 @@ Django==1.10.6
 psycopg2==2.7.1
 selenium==3.3.1
 coverage==4.4
-pyproj==1.9.5.1
 Fabric==1.14.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     license="MIT",
     platforms=["any"],
     packages=find_packages(exclude=("example", "static", "env")),
-    install_requires = ['pyproj==1.9.5.1'],
     include_package_data=True,
     classifiers=[
         "Environment :: Web Environment",


### PR DESCRIPTION
I noticed you refactored the to use gdal in the widgets instead of pyproj and 0 dependencies is pretty sweet ! 👍   Makes things a bit easier for us installing from this branch using pipenv too, because [reasons](https://docs.pipenv.org/basics/#a-note-about-vcs-dependencies)