### PR TITLE
instances of DjangoGooglePointFieldWidget and DjangoGooglePointFieldWidget classes assigned into variables

### DIFF
--- a/mapwidgets/templates/mapwidgets/google-point-field-inline-widget.html
+++ b/mapwidgets/templates/mapwidgets/google-point-field-inline-widget.html
@@ -38,11 +38,11 @@
                     markerDeleteTriggerNameSpace: "google_point_map_widget:marker_delete",
                     placeChangedTriggerNameSpace: "google_point_map_widget:place_changed"
                 };
-                new DjangoGooglePointFieldWidget(mapWidgetOptions);
+                var widget = new DjangoGooglePointFieldWidget(mapWidgetOptions);
 
             {% else %}
                 var widgetDataTemplate = JSON.parse("{{ js_widget_data|escapejs }}");
-                new DjangoMapWidgetGenerater({
+                var widgetGenerater = new DjangoMapWidgetGenerater({
                     "widgetDataTemplate": widgetDataTemplate,
                     "mapOptions": mapOptions,
                     "fieldValue": fieldValue

--- a/mapwidgets/templates/mapwidgets/google-point-field-widget.html
+++ b/mapwidgets/templates/mapwidgets/google-point-field-widget.html
@@ -83,7 +83,7 @@
                 markerDeleteTriggerNameSpace: "google_point_map_widget:marker_delete",
                 placeChangedTriggerNameSpace: "google_point_map_widget:place_changed"
             };
-            new DjangoGooglePointFieldWidget(mapWidgetOptions);
+            var widget = new DjangoGooglePointFieldWidget(mapWidgetOptions);
             {% block extra_javascript %}
 
             {% endblock %}


### PR DESCRIPTION
This helps to override template files more easily.

Example of usage custom function over DjangoGooglePointFieldWidget:

**myapp/templates/mapwidgets/google-point-field-widget.html**:
```JavaScript
{% extends "mapwidgets/google-point-field-widget.html" %}

{% block extra_javascript %}
my_custom_function(widget);
{% endblock %}
```