### PR TITLE
Support Django 2.1 by adding Widget.render's argument renderer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.10
   - DJANGO_VERSION=1.11
+  - DJANGO_VERSION=2.0
+  - DJANGO_VERSION=2.1
 
 cache:
   directories:

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,6 +1,6 @@
 Installation
 ------------
-.. note:: The library has been tested against Python 2.7 and 3.4+.
+.. note:: The library has been tested against Python 2.7 and 3.4-3.6. It is compatible with Django 1.6-2.1.
 
 
 Installing from PyPi

--- a/mapwidgets/widgets.py
+++ b/mapwidgets/widgets.py
@@ -103,7 +103,7 @@ class GooglePointFieldWidget(BasePointFieldMapWidget):
 
         return forms.Media(js=js, css=css)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if not attrs:
             attrs = dict()
 
@@ -125,7 +125,10 @@ class GooglePointFieldWidget(BasePointFieldMapWidget):
 
         attrs.update(extra_attrs)
         self.as_super = super(GooglePointFieldWidget, self)
-        return self.as_super.render(name, value, attrs)
+        if renderer is not None:
+            return self.as_super.render(name, value, attrs, renderer)
+        else:
+            return self.as_super.render(name, value, attrs)
 
 
 class PointFieldInlineWidgetMixin(object):
@@ -143,7 +146,7 @@ class PointFieldInlineWidgetMixin(object):
         }
         return js_widget_params
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if not attrs:
             attrs = dict()
 
@@ -155,7 +158,10 @@ class PointFieldInlineWidgetMixin(object):
             "is_formset_empty_form_template": is_formset_empty_form_template
         })
         self.as_super = super(PointFieldInlineWidgetMixin, self)
-        return self.as_super.render(name, value, attrs)
+        if renderer is not None:
+            return self.as_super.render(name, value, attrs, renderer)
+        else:
+            return self.as_super.render(name, value, attrs)
 
 
 class GooglePointFieldInlineWidget(PointFieldInlineWidgetMixin, GooglePointFieldWidget):
@@ -219,7 +225,7 @@ class BaseStaticMapWidget(forms.Widget):
             "attrs": attrs
         }
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         context = self.get_context_data(name, value, attrs)
         template = self.get_template()
         return render_to_string(template, context)


### PR DESCRIPTION
To support Django < 1.11, the argument `renderer` is not handed over to the `super` class, if it is `None`.