### PR TITLE
Swapping longitude/latitude when returning Point() in JS script

### DIFF
--- a/mapwidgets/static/mapwidgets/js/django_mw_base.js
+++ b/mapwidgets/static/mapwidgets/js/django_mw_base.js
@@ -90,7 +90,7 @@
 		},
 		
 		updateLocationInput: function(lat, lng, place){
-			var location_input_val = "POINT (" + lat + " " + lng + ")";
+			var location_input_val = "POINT (" + lng + " " + lat + ")";
 			this.locationInput.val(location_input_val);
 			this.updateCoordinatesInputs(lat, lng);
 			this.addMarkerToMap(lat, lng);


### PR DESCRIPTION
Fix for longitude/latitude swap (see upstream issue 60: https://github.com/erdem/django-map-widgets/issues/60)

**Please note:** sorry I hadn't time to check the app tests, I can just see it fixes the issue locally (I am using GooglePointFieldWidget).