### PR TITLE
fix six imports (support django 3 / drop python 2)

### DIFF
--- a/mapwidgets/widgets.py
+++ b/mapwidgets/widgets.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 from django import forms
 from django.contrib.gis.forms import BaseGeometryWidget
@@ -6,7 +7,6 @@ from django.contrib.gis.geos import Point
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string
 from django.templatetags.static import static
-from django.utils import six
 from django.utils.http import urlencode
 
 from mapwidgets.constants import STATIC_MAP_PLACEHOLDER_IMAGE

--- a/tests/testapp/widgets/tests/test_settings.py
+++ b/tests/testapp/widgets/tests/test_settings.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
+from six.moves import reload_module
 
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.six.moves import reload_module
 
 from mapwidgets.settings import MapWidgetSettings, DEFAULTS
 

--- a/tests/testapp/widgets/tests/test_widgets.py
+++ b/tests/testapp/widgets/tests/test_widgets.py
@@ -7,9 +7,9 @@ try:
 except ImportError:
     from urllib import urlopen
 
+from six.moves import reload_module
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.six.moves import reload_module
 from django.contrib.gis.geos import Point
 from django.utils.html import escapejs
 from django.conf import settings as test_app_settings


### PR DESCRIPTION
lets move on together in this PR :-)

one thing to improve would be to drop the usage of `six` all together.