### PR TITLE
chore: drop six

### DIFF
--- a/mapwidgets/widgets.py
+++ b/mapwidgets/widgets.py
@@ -1,5 +1,4 @@
 import json
-import six
 
 from django import forms
 from django.contrib.gis.forms import BaseGeometryWidget
@@ -93,7 +92,7 @@ class GooglePointFieldWidget(BasePointFieldMapWidget):
             attrs = dict()
 
         field_value = {}
-        if value and isinstance(value, six.string_types):
+        if value and isinstance(value, str):
             value = self.deserialize(value)
             longitude, latitude = value.coords
             field_value['lng'] = longitude

--- a/tests/testapp/widgets/tests/test_settings.py
+++ b/tests/testapp/widgets/tests/test_settings.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from six.moves import reload_module
 
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/tests/testapp/widgets/tests/test_widgets.py
+++ b/tests/testapp/widgets/tests/test_widgets.py
@@ -2,12 +2,15 @@ import os
 import json
 
 try:
+    from importlib import reload as reload_module
+except ImportError:
+    from imp import reload as reload_module
+try:
     from urllib.request import urlopen
     from http.client import HTTPMessage
 except ImportError:
     from urllib import urlopen
 
-from six.moves import reload_module
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.gis.geos import Point


### PR DESCRIPTION
six is no longer needed in Python 3

Supersedes https://github.com/erdem/django-map-widgets/issues/116