### PR TITLE
settings: allow disabling streetview

### DIFF
--- a/docs/widgets/point_field_map_widgets.rst
+++ b/docs/widgets/point_field_map_widgets.rst
@@ -44,6 +44,8 @@ Settings
 
 * **markerFitZoom** : When the marker is initialized google's default zoom is set to Max. This method sets the zoom level a reasonable distance and center the marker on the map.
 
+* **streetViewControl** : Whether or not to display the Street View "Peg Man" (optional, default is ``True``). Setting this to ``False`` effectively disables Street View for the widget.
+
 Usage
 ^^^^^
 
@@ -59,6 +61,7 @@ In your ``settings.py`` file, add your ``MAP_WIDGETS`` config:
             ("mapCenterLocationName", "london"),
             ("GooglePlaceAutocompleteOptions", {'componentRestrictions': {'country': 'uk'}}),
             ("markerFitZoom", 12),
+            ("streetViewControl", True),
         ),
         "GOOGLE_MAP_API_KEY": "<google-api-key>"
     }

--- a/mapwidgets/settings.py
+++ b/mapwidgets/settings.py
@@ -14,6 +14,7 @@ DEFAULTS = {
         ("zoom", 6),
         ("GooglePlaceAutocompleteOptions", {}),
         ("markerFitZoom", 15),
+        ("streetViewControl", True),
     ),
 
     "GoogleStaticMapWidget": (

--- a/mapwidgets/static/mapwidgets/js/mw_google_point_field.js
+++ b/mapwidgets/static/mapwidgets/js/mw_google_point_field.js
@@ -18,7 +18,8 @@
                         zoomControlOptions: {
                             position: google.maps.ControlPosition.RIGHT
                         },
-                        zoom: this.zoom
+                        zoom: this.zoom,
+                        streetViewControl: this.streetViewControl
                     });
 
                     $(this.mapElement).data('google_map', this.map);
@@ -38,7 +39,8 @@
                     zoomControlOptions: {
                         position: google.maps.ControlPosition.RIGHT
                     },
-                    zoom: this.zoom
+                    zoom: this.zoom,
+                    streetViewControl: this.streetViewControl
                 });
                 
                 $(this.mapElement).data('google_map', this.map);

--- a/mapwidgets/templates/mapwidgets/google-point-field-widget.html
+++ b/mapwidgets/templates/mapwidgets/google-point-field-widget.html
@@ -78,6 +78,7 @@
                 zoom: mapOptions.zoom,
                 markerFitZoom: mapOptions.markerFitZoom,
                 GooglePlaceAutocompleteOptions: mapOptions.GooglePlaceAutocompleteOptions,
+                streetViewControl: mapOptions.streetViewControl,
                 markerCreateTriggerNameSpace: "google_point_map_widget:marker_create",
                 markerChangeTriggerNameSpace: "google_point_map_widget:marker_change",
                 markerDeleteTriggerNameSpace: "google_point_map_widget:marker_delete",


### PR DESCRIPTION
Exposes a settings key which hides the Google Street View "peg man", as per: https://developers.google.com/maps/documentation/javascript/streetview#StreetViewMapUsage

This is a useful feature to have -- there are occasions where one wants to prevent end-users from accessing streetview.