### PR TITLE
Change import to support Django 4.0

### DIFF
--- a/mapwidgets/settings.py
+++ b/mapwidgets/settings.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from django.conf import settings as django_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.test.signals import setting_changed
 
 from mapwidgets.constants import TIMEZONE_COORDINATES


### PR DESCRIPTION
[Django 4.0 removed the ugettext_ family of functions](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0) so this import statement needs updating.