### PR TITLE
Update Django versions to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,21 @@ dist: xenial
 language: python
 
 python:
-  - 2.7
   - 3.8
 
 env:
-  - DJANGO_VERSION=1.11
-  - DJANGO_VERSION=2.0
-  - DJANGO_VERSION=2.1
   - DJANGO_VERSION=2.2
-  - DJANGO_VERSION=3.0
-  - DJANGO_VERSION=3.1
   - DJANGO_VERSION=3.2
+  - DJANGO_VERSION=4.0
 
 matrix:
     exclude:
-        - python: 2.7
-          env: DJANGO_VERSION=2.0
-        - python: 2.7
-          env: DJANGO_VERSION=2.1
-        - python: 2.7
+        - python: 3.8
           env: DJANGO_VERSION=2.2
-        - python: 2.7
-          env: DJANGO_VERSION=3.0
-        - python: 2.7
-          env: DJANGO_VERSION=3.1
-        - python: 2.7
+        - python: 3.8
           env: DJANGO_VERSION=3.2
+        - python: 3.8
+          env: DJANGO_VERSION=4.0
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa


### PR DESCRIPTION
This removes EOL python 2.7, and all non-LTS django versions that are out of supported.
Also, Django 4.0 which is now released is added to testing.