### PR TITLE
Un-exclude Python 3.8 from travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,6 @@ env:
   - DJANGO_VERSION=3.2
   - DJANGO_VERSION=4.0
 
-matrix:
-    exclude:
-        - python: 3.8
-          env: DJANGO_VERSION=2.2
-        - python: 3.8
-          env: DJANGO_VERSION=3.2
-        - python: 3.8
-          env: DJANGO_VERSION=4.0
-
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update


### PR DESCRIPTION
Looks like I accidentally stopped testing all configurations when trying to remove python 2.7 from testing, since Python 2.7 was already excluded, and I inadvertently excluded python 3.8 instead afterwards.

Follow-up from https://github.com/erdem/django-map-widgets/pull/129