### PR TITLE
assign DjangoGooglePointFieldWidget to const

### DIFF
--- a/mapwidgets/templates/mapwidgets/google-point-field-widget.html
+++ b/mapwidgets/templates/mapwidgets/google-point-field-widget.html
@@ -85,7 +85,7 @@
                 markerDeleteTriggerNameSpace: "google_point_map_widget:marker_delete",
                 placeChangedTriggerNameSpace: "google_point_map_widget:place_changed"
             };
-            new DjangoGooglePointFieldWidget(mapWidgetOptions);
+            const mapWidget = new DjangoGooglePointFieldWidget(mapWidgetOptions);
             {% block extra_javascript %}
 
             {% endblock %}


### PR DESCRIPTION
If you want to interact with the widget with additional javascript (ie, be able to change the map location based on an additional "country" field elsewhere in the form), then does it make sense to assign it to a local const in the `extra_javascript` block?