### PR TITLE
Remove mentions of deprecated `map_width`, `map_height`

### DIFF
--- a/mapwidgets/widgets.py
+++ b/mapwidgets/widgets.py
@@ -27,7 +27,7 @@ class BasePointFieldMapWidget(BaseGeometryWidget):
     def __init__(self, *args, **kwargs):
         attrs = kwargs.get('attrs')
         self.attrs = {}
-        for key in ('geom_type', 'map_srid', 'map_width', 'map_height', 'display_raw'):
+        for key in ('geom_type', 'map_srid', 'display_raw'):
             if key in kwargs:
                 self.attrs[key] = kwargs.get(key)
             else:


### PR DESCRIPTION
`map_width` and `map_height` are deprecated since Django 4.2: https://docs.djangoproject.com/en/dev/releases/4.2/#id1 and will be removed in Django 5.1

Django 4.2 will be the only supported Django version starting from 30 Apr 2024 (1 month away)
https://endoflife.date/django

These params not used in the project, so it look safe to remove them.

P.S. unit tests (`fab docker_run_unit_tests`) only with fixes of imports that removed in recent django versions:
* `from django.conf.urls import url, include` -> `from django.urls import re_path, include`
* `from django.utils.encoding import force_text` -> `from django.utils.encoding import force_str`
Also I had to replace `mdillon/postgis` with `postgis/postgis`.

But these changes are not included to this PR