### PR TITLE
fix collectstatic command when using ManifestStaticFilesStorage

### DIFF
--- a/mapwidgets/static/mapwidgets/css/magnific-popup.css
+++ b/mapwidgets/static/mapwidgets/css/magnific-popup.css
@@ -413,5 +413,3 @@ img.mfp-img {
     padding-right: 6px;
   }
 }
-
-/*# sourceMappingURL=magnific-popup.css.map */


### PR DESCRIPTION
### Description:
Since version 0.5.0. our project doesn't build anymore because it fails during `collectstatic`.
This PR fixes it for me, but I'm not sure of any other side effects this change could have. So, if you decide this PR is not the right way to fix the issue, I'd appreciate a different solution because we can't upgrade to 0.5.0 atm.

### How to reproduce:
With a fresh django project that has django-map-widgets version 0.5.0 installed, add this to the settings:
```
STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
```
Then try to run `python manage.py collectstatic`. 
You will get an error like this:
```
ValueError: The file 'mapwidgets/css/magnific-popup.css.map' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x7fc7fb525e20>.
```

### Possible future improvements:
It might be worth having a CI check that runs `collectstatic` with different `STATICFILES_STORAGE` settings. (If you'd like a contribution, I might be able to give it a shot but not anytime soon.)

