### PR TITLE
fix: add referrerPolicy to OSM tile layer (closes #166)

### DIFF
--- a/mapwidgets/settings.py
+++ b/mapwidgets/settings.py
@@ -145,7 +145,7 @@ DEFAULT_SETTINGS = {
                 },
                 "tileLayer": {
                     "urlTemplate": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                    "options": {"maxZoom": 20},
+                    "options": {"maxZoom": 20, "referrerPolicy": "origin"},
                 },
                 "markerFitZoom": 14,
                 "showZoomNavigation": True,


### PR DESCRIPTION
## Summary
- Adds `referrerPolicy: "origin"` to the default Leaflet tile layer options
- OSM now enforces sending a referrer header per their [tile usage policy](https://operations.osmfoundation.org/policies/tiles/); without it, tiles are blocked
- Leaflet 1.9.4 (already used by this package) supports `referrerPolicy` as a `L.tileLayer` option

Closes #166